### PR TITLE
Add support for gpt-4o-mini

### DIFF
--- a/datasette_enrichments_gpt/__init__.py
+++ b/datasette_enrichments_gpt/__init__.py
@@ -51,6 +51,7 @@ class GptEnrichment(Enrichment):
                 choices=[
                     ("gpt-3.5-turbo", "gpt-3.5-turbo"),
                     ("gpt-4o", "gpt-4o"),
+                    ("gpt-4o-mini", "gpt-4o mini"),
                     ("gpt-4o-vision", "gpt-4o vision"),
                 ],
                 default="gpt-3.5-turbo",


### PR DESCRIPTION
Awesome plugin, thanks!

I'd love to be able to use 4o-mini, as it's both cheaper and more capable than gpt-3.5-turbo.